### PR TITLE
Add multiple method to pick the last tag

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -128,7 +128,8 @@ disable=print-statement,
         dict-keys-not-iterating,
         dict-values-not-iterating,
         super-on-old-class,
-        abstract-method
+        abstract-method,
+        old-style-class
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -449,10 +450,10 @@ variable-naming-style=snake_case
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=10
+max-args=11
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=9
+max-attributes=10
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/auto_tag/cli.py
+++ b/auto_tag/cli.py
@@ -5,6 +5,9 @@ CLI parser for auto-tag.
 import logging
 import argparse
 
+from auto_tag import constants
+from auto_tag import tag_search_strategy
+
 
 def get_parser():
     """Return the argument parser setup."""
@@ -39,5 +42,10 @@ def get_parser():
 
     parser.add_argument('--append-v-to-tag', action='store_true',
                         help='Append a v to the tag (ex v1.0.5)')
+
+    parser.add_argument('--tag-search-strategy',
+                        choices=constants.SEARCH_STRATEGYS,
+                        default=tag_search_strategy.DEFAULT_STRAGETY_NAME,
+                        help='Strategy for searching the tag.')
 
     return parser

--- a/auto_tag/constants.py
+++ b/auto_tag/constants.py
@@ -12,6 +12,19 @@ CHANGE_TYPE_PAIRS = (
     (PATCH, 'PATCH'),
 )
 
+SEARCH_STRATEGY_BIGGEST_TAG_IN_REPO = 'biggest-tag-in-repo'
+SEARCH_STRATEGY_BIGGEST_TAG_IN_BRANCH = 'biggest-tag-in-branch'
+SEARCH_STRATEGY_LATEST_TAG_IN_REPO = 'latest-tag-in-repo'
+SEARCH_STRATEGY_LATEST_TAG_IN_BRANCH = 'latest-tag-in-branch'
+
+SEARCH_STRATEGYS = [
+    SEARCH_STRATEGY_BIGGEST_TAG_IN_REPO,
+    SEARCH_STRATEGY_BIGGEST_TAG_IN_BRANCH,
+    SEARCH_STRATEGY_LATEST_TAG_IN_REPO,
+    SEARCH_STRATEGY_LATEST_TAG_IN_BRANCH,
+]
+
+# pylint: disable=unnecessary-comprehension
 CHANGE_TYPES = {value: name for value, name in CHANGE_TYPE_PAIRS}
 CHANGE_TYPES_REVERSE = {name: value for value, name in CHANGE_TYPE_PAIRS}
 

--- a/auto_tag/entrypoint.py
+++ b/auto_tag/entrypoint.py
@@ -6,7 +6,7 @@ import sys
 import logging
 import logging.config
 
-from auto_tag import core, cli, detectors_config
+from auto_tag import core, cli, detectors_config, tag_search_strategy
 
 
 def main(cli_args):
@@ -36,10 +36,14 @@ def main(cli_args):
             args.config)
     else:
         config = detectors_config.DetectorsConfig.from_default()
+
+    search_strategy = tag_search_strategy.SEARCH_METHODS_MAPPING[
+        args.tag_search_strategy]
     autotag = core.AutoTag(
         repo=args.repo, branch=args.branch,
         upstream_remotes=args.upstream_remote,
         detectors=config.detectors,
+        search_strategy=search_strategy,
         git_name=args.name, git_email=args.email,
         append_v=args.append_v_to_tag,
         skip_if_exists=args.skip_tag_if_one_already_present,

--- a/auto_tag/exception.py
+++ b/auto_tag/exception.py
@@ -22,3 +22,7 @@ class ConfigurationError(BaseAutoTagException):
 
 class CantFindBranch(BaseAutoTagException):
     """Can't find a specific branch"""
+
+
+class UnknowkSearchStrategy(BaseAutoTagException):
+    """Invalid search strategy."""

--- a/auto_tag/tag_search_strategy.py
+++ b/auto_tag/tag_search_strategy.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Automatically tags branches base on commit message
+"""
+import time
+
+import semantic_version
+
+from auto_tag import constants
+from auto_tag import exception
+
+
+# pylint: disable=unused-argument
+def clean_tag_name(tag_name):
+    """Remove common mistakes when using semantic versioning."""
+    for prefix in constants.PREFIX_TO_ELIMINATE:
+        if tag_name.startswith(prefix):
+            clean_tag = tag_name[len(prefix):]
+            return clean_tag
+    return tag_name
+
+
+def get_biggest_tag_in_repo(repo, *args, **kwargs):
+    """Return the last tag for the given repo in a Version class.
+    :param repo: Repository to query for tags
+    :type repo: git.Repo
+
+    :returns: The latest tag from the repository.
+    :rtype: str
+    """
+    sem_versions = [
+        (
+            tag,
+            semantic_version.Version(clean_tag_name(tag.name))
+        ) for tag in repo.tags
+    ]
+
+    if sem_versions:
+        latest_tag, _ = max(sem_versions, key=lambda x: x[1])
+        return latest_tag
+    return None
+
+
+def _get_tags_on_branch(repo, branch_name):
+    """Get all the tags on this specific branch.
+
+    :param repo: Repository to query for tags
+    :type repo: git.Repo
+
+    :param branch_name: name of the branch
+    :type branch_name: string
+
+    :returns: List of tags from this branch
+    :rtype: list
+    """
+    commits_to_tag = {tag.commit: tag for tag in repo.tags}
+    found_tags = []
+
+    for commit in repo.iter_commits(rev=branch_name):
+        if commit in commits_to_tag:
+            found_tags.append(
+                commits_to_tag[commit])
+    return found_tags
+
+
+def get_biggest_tag_in_branch(repo, branch, *args, **kwargs):
+    """Return the last tag for the given repo in a Version class.
+    :param repo: Repository to query for tags
+    :type repo: git.Repo
+
+    :returns: The latest tag from the repository
+    :rtype: str
+    """
+    tags = _get_tags_on_branch(repo, branch)
+
+    sem_versions = [
+        (
+            tag,
+            semantic_version.Version(clean_tag_name(tag.name))
+        ) for tag in tags
+    ]
+    if sem_versions:
+        latest_tag, _ = max(sem_versions, key=lambda x: x[1])
+        return latest_tag
+    return None
+
+
+def get_latest_tag_in_repo(repo, branch, *args, **kwargs):
+    """Return the last tag for the given repo in a Version class.
+    :param repo: Repository to query for tags
+    :type repo: git.Repo
+
+    :returns: The latest tag from the repository
+    :rtype: str
+    """
+    committed_date_to_tag = [
+        (time.gmtime(tag.commit.committed_date), tag) for tag in repo.tags
+    ]
+    # if there are no tags
+    if not committed_date_to_tag:
+        return None
+
+    committed_date_to_tag.sort(key=lambda x: x[0], reverse=True)
+
+    return committed_date_to_tag[0][1]
+
+
+def get_latest_tag_in_branch(repo, branch, *args, **kwargs):
+    """Return the last tag for the given repo in a Version class.
+    :param repo: Repository to query for tags
+    :type repo: git.Repo
+
+    :returns: The latest tag from the repository
+    :rtype: str
+    """
+    committed_date_to_tag = [
+        (
+            time.gmtime(tag.commit.committed_date),
+            tag
+        ) for tag in _get_tags_on_branch(repo, branch)
+    ]
+    # if there are no tags
+    if not committed_date_to_tag:
+        return None
+
+    committed_date_to_tag.sort(key=lambda x: x[0], reverse=True)
+
+    return committed_date_to_tag[0][1]
+
+
+SEARCH_METHODS_MAPPING = {
+    constants.SEARCH_STRATEGY_BIGGEST_TAG_IN_REPO:
+        get_biggest_tag_in_repo,
+
+    constants.SEARCH_STRATEGY_BIGGEST_TAG_IN_BRANCH:
+        get_biggest_tag_in_branch,
+
+    constants.SEARCH_STRATEGY_LATEST_TAG_IN_REPO:
+        get_latest_tag_in_repo,
+
+    constants.SEARCH_STRATEGY_LATEST_TAG_IN_BRANCH:
+        get_latest_tag_in_branch
+}
+
+DEFAULT_STRAGETY_NAME = constants.SEARCH_STRATEGY_BIGGEST_TAG_IN_BRANCH
+DEFAULT_STRATEGY = SEARCH_METHODS_MAPPING[DEFAULT_STRAGETY_NAME]
+
+
+def get_last_tag(repo, branch, search_method_name):
+    """Get the last tag according to the appropriate search strategy."""
+    search_strategy = SEARCH_METHODS_MAPPING.get(search_method_name, None)
+
+    if search_strategy is None:
+        raise exception.UnknowkSearchStrategy(
+            '{} is not a search strategy supported.Choose form {}'.format(
+                search_method_name, SEARCH_METHODS_MAPPING.keys()))

--- a/auto_tag/tests/test_core.py
+++ b/auto_tag/tests/test_core.py
@@ -10,6 +10,8 @@ import pytest
 from auto_tag import core
 # pylint:disable=invalid-name
 
+BIG_TAG = '100.100.100'
+
 TEST_DATA_SIMPLE_TAG_PATCH_BUMP = [
     ('0.0.1', '0.0.2'),
     ('0.1.1', '0.1.2'),
@@ -34,8 +36,15 @@ TEST_NAME_2 = 'test_user_2'
 TEST_EMAIL_2 = 'test_2@email.com'
 
 
-def test_simple_flow_no_existing_tag(simple_repo,  default_detectors):
-    """Test a simple flow locally."""
+def test_simple_flow_no_existing_tag(simple_repo, default_detectors):
+    """Test a simple flow.
+
+    Scenario:
+        A repository with a few commits but no tag.
+    Outcome:
+        Tag 0.0.1 should be created.
+
+    """
     repo = git.Repo(simple_repo, odbt=git.GitDB)
 
     autotag = core.AutoTag(
@@ -51,8 +60,75 @@ def test_simple_flow_no_existing_tag(simple_repo,  default_detectors):
 
 @pytest.mark.parametrize('existing_tag, next_tag',
                          TEST_DATA_SIMPLE_TAG_PATCH_BUMP)
+def test_simple_flow_existing_tag_and_extra_tag_on_separate_branch(
+        existing_tag, next_tag, simple_repo, default_detectors):
+    """Test to see if only specified branch is evaluated.
+
+    Idea:
+        If we already have tags on a another branch (let's say `new_branch`)
+        if we want to auto-tag branch `master` then we should only look
+        at tags on this branch.
+    Scenario:
+        Branch `master` has `current_tag` and `new_branch` has tag `BIG_TAG`.
+        `BIG_TAG` is bigger then `current_tag`.
+    Output:
+        When we auto-tag the `master` branch then it should apply `next_tag`
+    """
+    repo = git.Repo(simple_repo, odbt=git.GitDB)
+    repo.create_tag(
+        existing_tag,
+        ref=list(repo.iter_commits())[-1])
+
+    # create a bigger tag on a new branch
+    new_branch = repo.create_head('new_branch', force=True)
+    repo.head.reference = new_branch
+    # repo.head.reset(index=False, working_tree=False)
+
+    file_path = os.path.join(simple_repo, 'extra_file')
+    commit_text = 'commit an extra file'
+    open(file_path, 'w+').close()
+    extra_commit = repo.index.commit(commit_text)
+    repo.create_tag(BIG_TAG, extra_commit)
+
+    autotag = core.AutoTag(
+        repo=simple_repo,
+        branch='master',
+        upstream_remotes=None,
+        detectors=default_detectors,
+        git_name=TEST_NAME,
+        git_email=TEST_EMAIL)
+
+    autotag.work()
+    assert next_tag in repo.tags
+
+
+# pylint: disable=unused-argument, fixme
+@pytest.mark.parametrize('existing_tag, next_tag',
+                         TEST_DATA_SIMPLE_TAG_PATCH_BUMP)
+def test_simple_flow_existing_tag_and_tag_exists_on_another_branch(
+        existing_tag, next_tag, simple_repo, default_detectors):
+    """Test to see if only specified branch is evaluated.
+
+    Idea:
+        If we already have tags on a dolerite branch (let's say `new_branch`)
+        if we want to auto-tag branch `master` then we should only look
+        at tags on this branch.
+    Scenario:
+        Branch `master` has `current_tag` and `new_branch` has tag
+        `next_tag`.
+        `next_tag` is bigger then `current_tag`.
+    Output:
+        When we auto-tag the `master` branch then it should throw an error
+        because we can't have two tags with the same name.
+    """
+    # TODO(mmicu): to be implemented
+    assert True
+
+
+@pytest.mark.parametrize('existing_tag, next_tag',
+                         TEST_DATA_SIMPLE_TAG_PATCH_BUMP)
 def test_simple_flow_existing_tag(
-        existing_tag, next_tag, simple_repo,  default_detectors):
+        existing_tag, next_tag, simple_repo, default_detectors):
     """Test a simple flow locally."""
     repo = git.Repo(simple_repo, odbt=git.GitDB)
     repo.create_tag(
@@ -73,8 +149,8 @@ def test_simple_flow_existing_tag(
 
 @pytest.mark.parametrize('existing_tag, next_tag',
                          TEST_DATA_SIMPLE_TAG_PATCH_BUMP)
-def test_simple_flow_existing_tag(
-        existing_tag, next_tag, simple_repo,  default_detectors):
+def test_simple_flow_existing_tag_mixed_tags(
+        existing_tag, next_tag, simple_repo, default_detectors):
     """Test a simple flow locally."""
     repo = git.Repo(simple_repo, odbt=git.GitDB)
     repo.create_tag(
@@ -93,8 +169,8 @@ def test_simple_flow_existing_tag(
     assert next_tag in repo.tags
 
 
-def test_simple_flow_existing_tag_mixed_tags(simple_repo,
-                                             default_detectors):
+def test_simple_flow_existing_tag_mixed_tag(simple_repo,
+                                            default_detectors):
     """Test the support for mixed tags."""
     repo = git.Repo(simple_repo, odbt=git.GitDB)
     repo.create_tag(
@@ -120,7 +196,7 @@ def test_simple_flow_existing_tag_mixed_tags(simple_repo,
 @pytest.mark.parametrize('existing_tag, next_tag',
                          TEST_DATA_SIMPLE_TAG_PATCH_BUMP)
 def test_simple_flow_existing_tag_on_last_commit(
-        existing_tag, next_tag, simple_repo,  default_detectors):
+        existing_tag, next_tag, simple_repo, default_detectors):
     """Test a simple flow locally."""
     repo = git.Repo(simple_repo, odbt=git.GitDB)
     repo.create_tag(
@@ -143,7 +219,7 @@ def test_simple_flow_existing_tag_on_last_commit(
 @pytest.mark.parametrize('existing_tag, next_tag',
                          TEST_DATA_SIMPLE_TAG_PATCH_BUMP)
 def test_simple_flow_existing_tag_append_v(
-        existing_tag, next_tag, simple_repo,  default_detectors):
+        existing_tag, next_tag, simple_repo, default_detectors):
     """Test a simple flow locally."""
     repo = git.Repo(simple_repo, odbt=git.GitDB)
     repo.create_tag(

--- a/auto_tag/tests/test_tag_search_strategy.py
+++ b/auto_tag/tests/test_tag_search_strategy.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Test simple flows of the AutoTag application
+"""
+import os
+
+import git
+import pytest
+import time
+
+from auto_tag import tag_search_strategy
+# pylint:disable=invalid-name
+
+
+SCENARIOS = [
+    (tag_search_strategy.get_biggest_tag_in_repo, 'branch_a', '1.1.1'),
+    (tag_search_strategy.get_biggest_tag_in_branch, 'branch_a', '1.0.1'),
+    (tag_search_strategy.get_latest_tag_in_repo, 'branch_a', '1.1.1'),
+    (tag_search_strategy.get_latest_tag_in_branch, 'branch_a', '0.1.1'),
+]
+
+
+@pytest.mark.parametrize('search_strategy, target_branch, expected_tag',
+                         SCENARIOS)
+def test_tag_search_strategy(search_strategy, target_branch, expected_tag,
+                             simple_repo_two_branches):
+    """Test to see if `get_biggest_tag_in_repo` returns the biggest tag
+       from all branches
+
+    Idea:
+        If we have two branches `banch_a` and `branch_b`
+        `branch_a` has the following tags applied in this order: 
+            `0.0.1`
+            `1.0.1`
+            `0.1.1`
+        `branch_b` has the following tags applied in this order: 
+            `1.1.1`
+    """
+    repo = git.Repo(simple_repo_two_branches, odbt=git.GitDB)
+
+    # search for tag
+    found_tag = search_strategy(repo=repo, branch=target_branch)
+    assert found_tag is not None
+    assert found_tag.name == expected_tag

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ README = open(
 # This call to setup() does all the work
 setup(
     name='auto-tag',
-    version='0.7.3',
+    version='0.8.3',
     description='Automatically tag a branch based on commit message',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-pylint==2.3.1
 pytest==5.3.2
+pylint==2.4.2
 pytest-cov==2.7.1
 pytest-parallel==0.0.9
 codecov==2.0.15


### PR DESCRIPTION
Previously the biggest tag (compared as semantic version) was chosen regarding
on what branch it was. Now the default behavior is to consider only tags on the
specified branch.

The previous default had the following limitations:

- you can't do for example a patch bump on an old version
- sometimes it makes sense to consider the latest tag applied not to compare
  them as semantic versions.

A new CLI option was added to select the search strategy for the last tag.