### PR TITLE
chore: update dependencies and clean up dead packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,4 @@ types-pyyaml = "*"
 [packages]
 auto-tag = {editable = true,path = "."}
 gitpython = ">=3.1.1"
+pyyaml = ">=5.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ twine = "*"
 auto-tag = {editable = true,path = "."}
 mypy = "*"
 importlib_metadata = "*"
-types-six = "*"
 types-pyyaml = "*"
 
 

--- a/auto_tag/detectors.py
+++ b/auto_tag/detectors.py
@@ -8,16 +8,13 @@ from typing import Any, NoReturn
 import abc
 import logging
 import re
-import six
-
 import git
 
 from auto_tag import constants
 from auto_tag import exception
 
 
-@six.add_metaclass(abc.ABCMeta)
-class BaseDetector():
+class BaseDetector(metaclass=abc.ABCMeta):
     """Base detector class."""
 
     def __init__(self, name: str, change_type: str,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,5 @@ setup(
     install_requires=[
         'gitpython>=3.1.18',
         'semantic_version>=2.8.5',
-        'confuse>=1.5.0',
-        'six>=1.1.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(
     install_requires=[
         'gitpython>=3.1.18',
         'semantic_version>=2.8.5',
+        'pyyaml>=5.1',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Development Status :: 3 - Alpha',
         'Environment :: MacOS X',
         'Environment :: Console',
@@ -43,6 +43,7 @@ setup(
         'Topic :: Software Development :: Version Control :: Git',
         'Topic :: System :: Software Distribution',
     ],
+    python_requires='>=3.10',
     packages=find_packages(exclude=('tests',)),
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
## Summary

Stacked on #330 (CI fixes).

- **Remove dead `confuse` dependency** — listed in `install_requires` but never imported anywhere in the codebase
- **Replace `six` with native Python 3** — `@six.add_metaclass(abc.ABCMeta)` replaced with `metaclass=abc.ABCMeta`; `six` and `types-six` removed from deps
- **Update setup.py classifiers** — replace stale Python 3.7/3.8/3.9 with 3.10/3.11/3.12 to match CI matrix; add `python_requires>=3.10`

## Dependency Audit — Major Updates (Manual Review Needed)

The following pinned dev dependencies are multiple major versions behind. They were **not** auto-updated because they require manual validation:

| Package | Current | Latest | Notes |
|---------|---------|--------|-------|
| pytest | 7.1.3 | 9.0.2 | Major: 7→9. pytest 8+ dropped some legacy APIs |
| pylint | 2.10.2 | 4.0.4 | Major: 2→4. Requires Python 3.9+, new config format |
| pytest-cov | 4.0.0 | 7.0.0 | Major: 4→7. Should be paired with pytest upgrade |

## Additional Recommendations

- **`Pipfile.lock` is stale** — contains yanked packages and old hashes; should be regenerated
- **`codecov` pip package is deprecated** — consider migrating to `codecov/codecov-action@v4` GitHub Action
- **Pre-existing test failures** — 60 of 80 tests fail due to `git init` defaulting to `main` instead of `master`; unrelated to this PR

## Test plan

- [x] All detector tests pass (17/17) — validates `six` removal
- [x] `BaseDetector` imports correctly with native `metaclass=abc.ABCMeta`
- [ ] CI validates on Python 3.10/3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)